### PR TITLE
Fix chaining example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ view.select(<CSS Selector>).html(htmContent);
 
 ### Chaining
 ```js
-myView = new Ity.view({ el: '.parentDiv'} );
+myView = new Ity.View({ el: '.parentDiv'} );
 myView.select('.myDiv').append('<p>Hi!</p>').parent().find('.myOtherDiv').remove();
 ```
 


### PR DESCRIPTION
## Summary
- update README to construct a `Ity.View` in the chaining example

## Testing
- `npm test` *(fails: no test specified)*