### PR TITLE
Add initial TypeScript support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ npm-debug.log
 *.sublime-project
 /npm-cache/
 .DS_Store
+coverage/
+build/

--- a/mini-mocha.ts
+++ b/mini-mocha.ts
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
+declare function require(id: string): any;
+declare const process: any;
 const path = require('path');
-const fs = require('fs');
 
-global.describe = function(desc, fn) {
+(globalThis as any).describe = function(desc: string, fn: () => void): void {
   console.log(desc);
   fn();
 };
 
-global.it = async function(desc, fn) {
+(globalThis as any).it = async function(desc: string, fn: () => Promise<void> | void): Promise<void> {
   try {
     await fn();
     console.log('  \u2714', desc);
@@ -19,6 +20,6 @@ global.it = async function(desc, fn) {
 };
 
 const files = process.argv.slice(2);
-files.forEach(file => {
+files.forEach((file: string) => {
   require(path.resolve(file));
 });

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "A miniscule, depedency free JavaScript MVC",
   "main": "Ity.js",
   "scripts": {
-    "test": "node mini-mocha.js test/*.js",
-    "coverage": "rm -rf coverage && NODE_V8_COVERAGE=coverage node mini-mocha.js test/*.js && node reportCoverage.js"
+    "test": "node build/mini-mocha.js test/*.js",
+    "coverage": "rm -rf coverage && NODE_V8_COVERAGE=coverage node build/mini-mocha.js test/*.js && node reportCoverage.js",
+    "pretest": "tsc"
   },
   "devDependencies": {
     "mocha": "2.1.x",
@@ -13,7 +14,9 @@
     "gulp-uglify": "1.2.*",
     "gulp-rename": "1.2.*",
     "gulp-sourcemaps": "1.5.2",
-    "vinyl-buffer": "1.0.0"
+    "vinyl-buffer": "1.0.0",
+    "typescript": "^5.4.2",
+    "ts-node": "^10.9.1"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ES2020", "DOM"],
+    "outDir": "build"
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add TypeScript compiler configuration
- convert `mini-mocha.js` test runner to TypeScript
- compile TypeScript before running tests
- ignore build and coverage output

## Testing
- `npm test`
- `npm run coverage`
