### PR TITLE
Add Router with SPA-style routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,6 @@ A miniscule, dependency free JavaScript MVC
 * Mobile first - no legacy hackery for ie < 10.
 * Great for spinning up small, mobile-specific apps
 
-## To Do
-* Currently no router for fancy SPA style urls
-
-
 ## Installation
 ```
 npm install ity
@@ -77,7 +73,21 @@ const myView = new Ity.View({
 * View.on(eventName, callback) - listen to View instance events and call callback function
 * View.remove() - Remove internal el element and remove view from app
 * View.trigger(eventName, data) - trigger event by name on View instance and optionally pass data
-* View.select(DOMquery) - select DOM elements within set el object. 
+* View.select(DOMquery) - select DOM elements within set el object.
+
+## Router
+* Router.addRoute(pattern, handler) - register a URL pattern and callback. Dynamic segments prefixed with `:` become params.
+* Router.navigate(path) - update the history state and dispatch the matching route.
+* Router.start() - start listening for `popstate` events (called automatically on creation).
+* Router.stop() - stop listening for URL changes.
+
+```ts
+const router = new Ity.Router();
+router.addRoute('/users/:id', params => {
+  console.log('Showing user', params.id);
+});
+router.navigate('/users/5');
+```
 
 ## The Selection Engine and Selector object
 Based on jQuery's DOM querying. Selection is done from within a View instance. 

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -1,0 +1,47 @@
+// @ts-nocheck
+export {};
+declare var require: any;
+declare function describe(desc: string, fn: () => void): void;
+declare function it(desc: string, fn: () => any): void;
+const assert = require('assert');
+const { setupDOM } = require('./helpers');
+
+describe('Router', function () {
+  it('navigates to a route', function () {
+    const cleanup = setupDOM();
+    const router = new window.Ity.Router();
+    let hit = false;
+    router.addRoute('/foo', () => { hit = true; });
+    router.navigate('/foo');
+    assert(hit);
+    cleanup();
+  });
+
+  it('passes params from route', function () {
+    const cleanup = setupDOM();
+    const router = new window.Ity.Router();
+    let param: string | undefined;
+    router.addRoute('/users/:id', (p) => { param = p.id; });
+    router.navigate('/users/42');
+    assert.equal(param, '42');
+    cleanup();
+  });
+
+  it('start and stop listening to popstate', function () {
+    const cleanup = setupDOM();
+    const router = new window.Ity.Router();
+    let count = 0;
+    router.addRoute('/bar', () => { count++; });
+    router.navigate('/bar');
+    assert.equal(count, 1);
+    router.stop();
+    window.history.pushState(null, '', '/bar');
+    window.dispatchEvent(new window.Event('popstate'));
+    assert.equal(count, 1);
+    router.start();
+    window.history.pushState(null, '', '/bar');
+    window.dispatchEvent(new window.Event('popstate'));
+    assert.equal(count, 3);
+    cleanup();
+  });
+});


### PR DESCRIPTION
## Summary
- implement new `Router` class with route registration and navigation
- export the router from the library
- document Router usage in the README and remove obsolete TODO
- provide polyfills for history/event helpers in tests
- add comprehensive Router tests

## Testing
- `npm test`
- `npm run coverage`
