### PR TITLE
Fix html() replacement for SelectorObject lists

### DIFF
--- a/Ity.ts
+++ b/Ity.ts
@@ -157,18 +157,18 @@ declare var define: any;
       for (const node of this.nodes) {
         if (!isSelectorObject) {
           const html = (content as HTMLElement).outerHTML ?? String(content);
-          if (position !== 'replace') {
-            node.insertAdjacentHTML(position as InsertPosition, html);
-          } else {
+          if (position === 'replace') {
             node.innerHTML = html;
+          } else {
+            node.insertAdjacentHTML(position as InsertPosition, html);
           }
         } else {
-          for (const selNode of content as SelectorObject) {
-            const html = selNode.outerHTML;
-            if (position !== 'replace') {
+          const htmls = Array.from(content as SelectorObject).map((selNode) => selNode.outerHTML);
+          if (position === 'replace') {
+            node.innerHTML = htmls.join('');
+          } else {
+            for (const html of htmls) {
               node.insertAdjacentHTML(position as InsertPosition, html);
-            } else {
-              node.innerHTML = html;
             }
           }
         }

--- a/test/selectorHtml.test.ts
+++ b/test/selectorHtml.test.ts
@@ -38,4 +38,19 @@ describe('SelectorObject HTML insertion', function () {
     assert.equal(target.first()[0].id, 'target');
     cleanup();
   });
+
+  it('html with multiple elements replaces correctly', function () {
+    const cleanup = setupDOM('<!DOCTYPE html><div id="target"></div><div class="one"></div><div class="two"></div>');
+    const target = new window.Ity.SelectorObject([document.getElementById('target')]);
+    const multi = new window.Ity.SelectorObject([
+      document.querySelector('.one'),
+      document.querySelector('.two'),
+    ]);
+    target.html(multi);
+    const children = target.first()[0].children;
+    assert.equal(children.length, 2);
+    assert(children[0].classList.contains('one'));
+    assert(children[1].classList.contains('two'));
+    cleanup();
+  });
 });


### PR DESCRIPTION
## Summary
- handle multiple elements in `SelectorObject.html`
- test html replacement with multiple elements

## Testing
- `npm test`