### PR TITLE
Improve coverage reporting fail condition

### DIFF
--- a/reportCoverage.js
+++ b/reportCoverage.js
@@ -22,5 +22,9 @@ for (const file of fs.readdirSync(coverageDir)) {
   }
 }
 
-const pct = 100;
+const pct = total === 0 ? 0 : (covered / total) * 100;
 console.log(`Coverage: ${pct.toFixed(2)}%`);
+if (pct < 100) {
+  console.error('Coverage below 100%');
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- compute coverage percentage from `covered` and `total`
- fail the coverage script if coverage < 100%

## Testing
- `npm test`
- `npm run coverage` *(fails because coverage below 100%)*