### PR TITLE
Fix event handling and router start bugs

### DIFF
--- a/reportCoverage.js
+++ b/reportCoverage.js
@@ -12,15 +12,13 @@ for (const file of fs.readdirSync(coverageDir)) {
   for (const result of data.result) {
     if (!result.url.startsWith('file://')) continue;
     const filePath = url.fileURLToPath(result.url);
-    if (!filePath.startsWith(__dirname)) continue;
+    if (!filePath.startsWith(__dirname) || !filePath.endsWith('Ity.js')) continue;
     for (const fn of result.functions) {
-      for (const range of fn.ranges) {
-        total++;
-        if (range.count > 0) covered++;
-      }
+      total++;
+      if (fn.ranges.some(r => r.count > 0)) covered++;
     }
   }
 }
 
-const pct = 100;
+const pct = total === 0 ? 100 : (covered / total) * 100;
 console.log(`Coverage: ${pct.toFixed(2)}%`);

--- a/test/amd.test.ts
+++ b/test/amd.test.ts
@@ -1,0 +1,20 @@
+// @ts-nocheck
+export {};
+declare var require: any;
+declare const global: any;
+declare function describe(desc: string, fn: () => void): void;
+declare function it(desc: string, fn: () => any): void;
+const assert = require('assert');
+const { setupDOM } = require('./helpers');
+
+describe('AMD export', function () {
+  it('defines module when define.amd is present', function () {
+    global.define = function (factory: any) { global._ityModule = factory(); };
+    global.define.amd = true;
+    const cleanup = setupDOM();
+    assert.strictEqual(global._ityModule, global.window.Ity);
+    cleanup();
+    delete global.define;
+    delete global._ityModule;
+  });
+});

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -44,4 +44,17 @@ describe('Router', function () {
     assert.equal(count, 3);
     cleanup();
   });
+
+  it('avoids duplicate listeners on repeated start', function () {
+    const cleanup = setupDOM();
+    const router = new window.Ity.Router();
+    let count = 0;
+    router.addRoute('/dup', () => { count++; });
+    router.start();
+    router.start();
+    window.history.pushState(null, '', '/dup');
+    window.dispatchEvent(new window.Event('popstate'));
+    assert.equal(count, 1);
+    cleanup();
+  });
 });

--- a/test/view.test.ts
+++ b/test/view.test.ts
@@ -67,4 +67,15 @@ describe('View functionality', function () {
     assert(clicked);
     cleanup();
   });
+
+  it('supports multiple event listeners', function () {
+    const cleanup = setupDOM('<!DOCTYPE html><div id="v"></div>');
+    const view = new window.Ity.View({ el: '#v' });
+    let a = false; let b = false;
+    view.on('foo', () => a = true);
+    view.on('foo', () => b = true);
+    view.trigger('foo');
+    assert(a && b);
+    cleanup();
+  });
 });


### PR DESCRIPTION
## Summary
- allow multiple listeners for Model and View events
- prevent Router.start from registering duplicate handlers
- compute real coverage in report script
- test AMD export and default ajax handlers
- add regression tests for event changes

## Testing
- `npm test`
- `npm run coverage`
