### PR TITLE
Fix Model.unSet removal check

### DIFF
--- a/Ity.ts
+++ b/Ity.ts
@@ -252,7 +252,7 @@ declare var define: any;
     }
 
     unSet(attr: keyof T): void {
-      if (this.data && (this.data as any)[attr] !== undefined) {
+      if (this.data && Object.prototype.hasOwnProperty.call(this.data, attr)) {
         delete (this.data as any)[attr];
         this.trigger("change", this.data);
       }

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -29,6 +29,15 @@ describe('Model basics', function () {
     cleanup();
   });
 
+  it('unSet removes attributes set to undefined', function () {
+    const cleanup = setupDOM();
+    const model = new window.Ity.Model();
+    model.set('x', undefined);
+    model.unSet('x');
+    assert.strictEqual('x' in model.get(), false);
+    cleanup();
+  });
+
   it('triggers change events', function () {
     const cleanup = setupDOM();
     const model = new window.Ity.Model();


### PR DESCRIPTION
## Summary
- remove attribute when value is undefined in `Model.unSet`
- add regression test for undefined value removal

## Testing
- `npm test --silent`
- `npm run coverage --silent`