### PR TITLE
Fix router query/hash params

### DIFF
--- a/Ity.ts
+++ b/Ity.ts
@@ -476,12 +476,22 @@ declare var define: any;
     }
 
     private _checkUrl(): void {
-      const path = window.location.pathname.replace(/\/?$/, "");
+      const path = window.location.pathname.replace(/[?#].*$/, "").replace(/\/?$/, "");
       for (const route of this.routes) {
         const match = route.re.exec(path);
         if (match) {
           const params: Record<string, string> = {};
           route.keys.forEach((k, i) => (params[k] = match[i + 1]));
+          const collect = (str: string): void => {
+            str = str.replace(/^[?#]/, "");
+            if (!str) return;
+            const search = new URLSearchParams(str);
+            search.forEach((v, k) => {
+              params[k] = v;
+            });
+          };
+          collect(window.location.search);
+          collect(window.location.hash);
           route.handler(params);
           break;
         }

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ const myView = new Ity.View({
 * Router.navigate(path) - update the history state and dispatch the matching route.
 * Router.start() - start listening for `popstate` events (called automatically on creation).
 * Router.stop() - stop listening for URL changes.
+* Query string (`?foo=bar`) and hash (`#section=2`) parameters are parsed and merged into the handler's params object.
 
 ```ts
 const router = new Ity.Router();

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -44,12 +44,15 @@ export function setupDOM(html: string = '<!DOCTYPE html><div id="root"></div>') 
       stack: ["/"],
       pushState: function (_s: any, _t: any, path: string) {
         this.stack.push(path);
-        global.window.location.pathname = path;
+        const url = new URL(path, "http://ity.local");
+        global.window.location.pathname = url.pathname;
+        global.window.location.search = url.search;
+        global.window.location.hash = url.hash;
       },
     } as any;
   }
   if (!global.window.location) {
-    global.window.location = { pathname: "/" } as any;
+    global.window.location = { pathname: "/", search: "", hash: "" } as any;
   }
   if (!global.window.HTMLElement.prototype.getAttribute) {
     global.window.HTMLElement.prototype.getAttribute = function (name: string): any {

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -57,4 +57,14 @@ describe('Router', function () {
     assert.equal(count, 1);
     cleanup();
   });
+
+  it('parses query and hash parameters', function () {
+    const cleanup = setupDOM();
+    const router = new window.Ity.Router();
+    let params: any;
+    router.addRoute('/users/:id', (p) => { params = p; });
+    router.navigate('/users/7?foo=bar#baz=qux');
+    assert.deepStrictEqual(params, { id: '7', foo: 'bar', baz: 'qux' });
+    cleanup();
+  });
 });


### PR DESCRIPTION
## Summary
- capture query and hash parameters in Router
- simulate history pushState with search and hash during tests
- test query/hash parameter parsing
- document Router query/hash parsing

## Testing
- `npm test`