### PR TITLE
Add ESM and CJS build outputs

### DIFF
--- a/Examples/Collection/collectionApp.ts
+++ b/Examples/Collection/collectionApp.ts
@@ -1,0 +1,36 @@
+declare function require(deps: string[], cb: (Ity: any) => void): void;
+
+require(['../../../Ity'], (Ity: any) => {
+  initCollection(Ity);
+});
+
+const initCollection = (Ity: any): void => {
+  const app = new Ity.Application();
+  const collection = new Ity.Collection([
+    new Ity.Model({ data: { name: 'Alice' } }),
+    new Ity.Model({ data: { name: 'Bob' } }),
+  ]);
+
+  const view = new Ity.View({
+    el: '#collectionApp',
+    app,
+    events: {
+      '.addItem': { click: 'addItem' }
+    },
+    initialize: function(this: any): void {
+      this.collection = collection;
+      this.render();
+    },
+    render: function(this: any): void {
+      const html = this.collection.models
+        .map((m: any) => `<li>${m.get('name')}</li>`) 
+        .join('');
+      this.select('ul').html(html);
+    },
+    addItem: function(this: any): void {
+      const name = `Item ${this.collection.models.length + 1}`;
+      this.collection.add(new Ity.Model({ data: { name } }));
+      this.render();
+    }
+  });
+};

--- a/Examples/Collection/index.html
+++ b/Examples/Collection/index.html
@@ -1,0 +1,12 @@
+<html>
+  <head>
+    <script src="http://requirejs.org/docs/release/2.1.17/minified/require.js"></script>
+    <script src="../../build/Examples/Collection/collectionApp.js"></script>
+  </head>
+  <body>
+    <div id="collectionApp">
+      <button class="addItem">Add</button>
+      <ul></ul>
+    </div>
+  </body>
+</html>

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ npm install ity
 ```ts
 const myApp = new Ity.Application();
 const myModel = new Ity.Model();
+const myCollection = new Ity.Collection([myModel]);
 const myView = new Ity.View({
   el: '.someElement',
   app: myApp,
@@ -62,8 +63,22 @@ const myView = new Ity.View({
 * Model.unSet(someDataPoint) - clear out valye of interanl data objecy by key
 * Model.clear() - clear entire internal data objecy
 * Model.on(eventName, callback) - listen to Model instance events and call callback function
+* Model.off(eventName?, callback?) - remove Model instance event listener(s)
 * Model.sync(options) - sync data in internal data object. Optionally pass options hash for url, type, success, error
 * Model.trigger(eventName, data) - trigger event by name on Model instance and optionally pass data
+
+## Collection
+* Collection.add(model) - add an Ity.Model instance to the collection
+* Collection.get(id) - return a model by id if present
+* Collection.remove(id) - remove a model from the collection by id
+* Collection.at(index) - return model at a given index
+* Collection.length - number of models in the collection
+* Collection.clear() - remove all models
+* Collection.find(fn) - return the first model matching `fn`
+* Collection.filter(fn) - return an array of models matching `fn`
+* Collection.toJSON() - array of each model's data
+* Collection.fetch(opts) - populate models from an AJAX request
+* Collection.trigger(eventName, data) - trigger event on all models in the collection
 
 ## View
 * View.initialize(options) - called on instantiation of View instances, optional options hash can be passed
@@ -71,6 +86,7 @@ const myView = new Ity.View({
 * View.get(key) - return attribute of view by key String
 * View.set(key, value) - set attribute of view to passed value
 * View.on(eventName, callback) - listen to View instance events and call callback function
+* View.off(eventName?, callback?) - remove View instance event listener(s)
 * View.remove() - Remove internal el element and remove view from app
 * View.trigger(eventName, data) - trigger event by name on View instance and optionally pass data
 * View.select(DOMquery) - select DOM elements within set el object.
@@ -80,6 +96,7 @@ const myView = new Ity.View({
 * Router.navigate(path) - update the history state and dispatch the matching route.
 * Router.start() - start listening for `popstate` events (called automatically on creation).
 * Router.stop() - stop listening for URL changes.
+* Query string (`?foo=bar`) and hash (`#section=2`) parameters are parsed and merged into the handler's params object.
 
 ```ts
 const router = new Ity.Router();
@@ -140,7 +157,8 @@ npm install
 npm run build
 ```
 
-This creates `dist/ity.js`, `dist/ity.min.js` and their source maps. You can verify
+This creates `dist/ity.js`, `dist/ity.min.js` and module builds in
+`dist/ity.esm.js` and `dist/ity.cjs.js`, along with their source maps. You can verify
 the minified build works by running:
 ```bash
 npm run test:dist

--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "ity",
   "version": "1.0.0",
   "description": "A miniscule, depedency free JavaScript MVC",
-  "main": "Ity.js",
+  "main": "dist/ity.cjs.js",
+  "module": "dist/ity.esm.js",
+  "exports": {
+    "import": "./dist/ity.esm.js",
+    "require": "./dist/ity.cjs.js"
+  },
   "scripts": {
     "test": "node build/mini-mocha.js build/test/*.js",
     "coverage": "rm -rf coverage && NODE_V8_COVERAGE=coverage node build/mini-mocha.js build/test/*.js && node reportCoverage.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,12 +5,11 @@ export default [
   {
     input: 'Ity.ts',
     plugins: [typescript()],
-    output: {
-      file: 'dist/ity.js',
-      format: 'iife',
-      name: 'Ity',
-      sourcemap: true
-    }
+    output: [
+      { file: 'dist/ity.js', format: 'iife', name: 'Ity', sourcemap: true },
+      { file: 'dist/ity.cjs.js', format: 'cjs', sourcemap: true },
+      { file: 'dist/ity.esm.js', format: 'es', sourcemap: true }
+    ]
   },
   {
     input: 'Ity.ts',

--- a/test/collection.test.ts
+++ b/test/collection.test.ts
@@ -1,0 +1,77 @@
+// @ts-nocheck
+export {};
+declare var require: any;
+declare function describe(desc: string, fn: () => void): void;
+declare function it(desc: string, fn: () => any): void;
+const assert = require('assert');
+const { setupDOM } = require('./helpers');
+
+describe('Collection', function () {
+  it('add, get and remove models', function () {
+    const cleanup = setupDOM();
+    const c = new window.Ity.Collection();
+    const m = new window.Ity.Model();
+    c.add(m);
+    assert.strictEqual(c.get(m.id), m);
+    c.remove(m.id);
+    assert.strictEqual(c.get(m.id), undefined);
+    cleanup();
+  });
+
+  it('initializes with models array', function () {
+    const cleanup = setupDOM();
+    const m1 = new window.Ity.Model();
+    const m2 = new window.Ity.Model();
+    const c = new window.Ity.Collection([m1, m2]);
+    assert.strictEqual(c.models.length, 2);
+    assert.strictEqual(c.at(1), m2);
+    cleanup();
+  });
+
+  it('triggers events on child models', function () {
+    const cleanup = setupDOM();
+    const c = new window.Ity.Collection();
+    const m = new window.Ity.Model();
+    c.add(m);
+    let triggered = false;
+    m.on('foo', () => triggered = true);
+    c.trigger('foo');
+    assert(triggered);
+    cleanup();
+  });
+
+  it('supports filter, find, clear and toJSON', function () {
+    const cleanup = setupDOM();
+    const c = new window.Ity.Collection();
+    const m1 = new window.Ity.Model();
+    const m2 = new window.Ity.Model();
+    m1.set('a', 1);
+    m2.set('a', 2);
+    c.add(m1);
+    c.add(m2);
+    assert.strictEqual(c.length, 2);
+    assert.strictEqual(c.find(m => m.get('a') === 2), m2);
+    assert.strictEqual(c.filter(m => m.get('a') > 0).length, 2);
+    assert.deepStrictEqual(c.toJSON(), [{a:1}, {a:2}]);
+    c.clear();
+    assert.strictEqual(c.length, 0);
+    cleanup();
+  });
+
+  it('fetch populates models via ajax', function () {
+    const cleanup = setupDOM();
+    const originalXHR = global.XMLHttpRequest;
+    function FakeXHR() {
+      this.open = () => {};
+      this.send = () => { this.status = 200; this.responseText = '[{"x":1},{"x":2}]'; this.onload(); };
+    }
+    global.XMLHttpRequest = function () { return new FakeXHR(); };
+    const c = new window.Ity.Collection([], window.Ity.Model);
+    c.url = '/foo';
+    c.fetch();
+    assert.strictEqual(c.length, 2);
+    assert.strictEqual(c.at(1).get('x'), 2);
+    global.XMLHttpRequest = originalXHR;
+    cleanup();
+  });
+});

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -44,12 +44,15 @@ export function setupDOM(html: string = '<!DOCTYPE html><div id="root"></div>') 
       stack: ["/"],
       pushState: function (_s: any, _t: any, path: string) {
         this.stack.push(path);
-        global.window.location.pathname = path;
+        const url = new URL(path, "http://ity.local");
+        global.window.location.pathname = url.pathname;
+        global.window.location.search = url.search;
+        global.window.location.hash = url.hash;
       },
     } as any;
   }
   if (!global.window.location) {
-    global.window.location = { pathname: "/" } as any;
+    global.window.location = { pathname: "/", search: "", hash: "" } as any;
   }
   if (!global.window.HTMLElement.prototype.getAttribute) {
     global.window.HTMLElement.prototype.getAttribute = function (name: string): any {

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -95,4 +95,18 @@ describe('Model basics', function () {
     global.XMLHttpRequest = originalXHR;
     cleanup();
   });
+
+  it('off removes event listeners', function () {
+    const cleanup = setupDOM();
+    const model = new window.Ity.Model();
+    let count = 0;
+    function cb() { count++; }
+    model.on('change', cb);
+    model.trigger('change');
+    assert.equal(count, 1);
+    model.off('change', cb);
+    model.trigger('change');
+    assert.equal(count, 1);
+    cleanup();
+  });
 });

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -57,4 +57,14 @@ describe('Router', function () {
     assert.equal(count, 1);
     cleanup();
   });
+
+  it('parses query and hash parameters', function () {
+    const cleanup = setupDOM();
+    const router = new window.Ity.Router();
+    let params: any;
+    router.addRoute('/users/:id', (p) => { params = p; });
+    router.navigate('/users/7?foo=bar#baz=qux');
+    assert.deepStrictEqual(params, { id: '7', foo: 'bar', baz: 'qux' });
+    cleanup();
+  });
 });

--- a/test/view.test.ts
+++ b/test/view.test.ts
@@ -79,6 +79,18 @@ describe('View functionality', function () {
     cleanup();
   });
 
+  it('off removes view event listeners', function () {
+    const cleanup = setupDOM('<!DOCTYPE html><div id="v"></div>');
+    const view = new window.Ity.View({ el: '#v' });
+    let called = false;
+    function cb() { called = true; }
+    view.on('bar', cb);
+    view.off('bar', cb);
+    view.trigger('bar');
+    assert.strictEqual(called, false);
+    cleanup();
+  });
+
   it('delegates focus events using capture', function () {
     const cleanup = setupDOM('<!DOCTYPE html><div id="v"><input id="i"></div>');
     let focused = false;


### PR DESCRIPTION
## Summary
- export library as a module
- add ES and CommonJS outputs to rollup
- expose module entry points in `package.json`
- document new build outputs
- merge latest master changes and ensure global export still works

## Testing
- `npm test`
