### PR TITLE
Add TypeScript declaration build

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ npm run build
 ```
 
 This creates `dist/ity.js`, `dist/ity.min.js` and module builds in
-`dist/ity.esm.js` and `dist/ity.cjs.js`, along with their source maps. You can verify
+`dist/ity.esm.js` and `dist/ity.cjs.js`, along with their source maps. A
+declaration file `dist/ity.d.ts` is also generated. You can verify
 the minified build works by running:
 ```bash
 npm run test:dist

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A miniscule, depedency free JavaScript MVC",
   "main": "dist/ity.cjs.js",
   "module": "dist/ity.esm.js",
+  "types": "dist/ity.d.ts",
   "exports": {
     "import": "./dist/ity.esm.js",
     "require": "./dist/ity.cjs.js"
@@ -21,7 +22,8 @@
     "ts-node": "^10.9.1",
     "rollup": "^4.17.0",
     "@rollup/plugin-typescript": "^11.1.0",
-    "rollup-plugin-terser": "^7.0.2"
+    "rollup-plugin-terser": "^7.0.2",
+    "rollup-plugin-dts": "^6.1.0"
   },
   "repository": {
     "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,6 @@
 import typescript from '@rollup/plugin-typescript';
 import { terser } from 'rollup-plugin-terser';
+import dts from 'rollup-plugin-dts';
 
 export default [
   {
@@ -19,6 +20,14 @@ export default [
       format: 'iife',
       name: 'Ity',
       sourcemap: true
+    }
+  },
+  {
+    input: 'Ity.ts',
+    plugins: [dts()],
+    output: {
+      file: 'dist/ity.d.ts',
+      format: 'es'
     }
   }
 ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,9 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "lib": ["ES2020", "DOM"],
-    "outDir": "build"
+    "outDir": "build",
+    "declaration": true,
+    "declarationDir": "types"
   },
   "include": ["**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- generate declaration files by enabling `declaration` options in `tsconfig.json`
- create `dist/ity.d.ts` via `rollup-plugin-dts`
- expose the generated types through the `types` field in `package.json`
- document generated declaration file in README

## Testing
- `npm test`