### PR TITLE
Fix rollup terser plugin dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ts-node": "^10.9.1",
     "rollup": "^4.17.0",
     "@rollup/plugin-typescript": "^11.1.0",
-    "rollup-plugin-terser": "^7.0.2",
+    "@rollup/plugin-terser": "^0.4.4",
     "rollup-plugin-dts": "^6.1.0"
   },
   "repository": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
-import { terser } from 'rollup-plugin-terser';
+import { terser } from '@rollup/plugin-terser';
 import dts from 'rollup-plugin-dts';
 
 export default [


### PR DESCRIPTION
## Summary
- switch to @rollup/plugin-terser which supports Rollup v4
- update rollup config to use new plugin

## Testing
- `npm test`