### PR TITLE
Fix test compilation error by excluding generated types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "declarationDir": "types"
   },
   "include": ["**/*.ts"],
-  "exclude": ["Examples/**/*"]
+  "exclude": ["Examples/**/*", "types/**/*"]
 }


### PR DESCRIPTION
## Summary
- prevent tsc from re-reading generated declaration files

## Testing
- `npm test`
- `npm test` (again)