### PR TITLE
Fix DOM setup for Jest and update event bubbling in tests

### DIFF
--- a/test/routerExample.test.ts
+++ b/test/routerExample.test.ts
@@ -49,7 +49,7 @@ describe('Router example logic', function () {
     const cleanup = setupDOM('<!DOCTYPE html><div id="routerApp"><button class="homeLink"></button><button class="userLink" data-calc-id="1"></button><div class="content"></div></div>');
     const { view } = createRouterView(window.Ity);
     const btn = document.querySelector('.homeLink') as HTMLElement;
-    btn.dispatchEvent(new window.Event('click'));
+    btn.dispatchEvent(new window.Event('click', { bubbles: true }));
     assert.strictEqual(view.model.get('page'), 'Home');
     cleanup();
   });
@@ -58,7 +58,7 @@ describe('Router example logic', function () {
     const cleanup = setupDOM('<!DOCTYPE html><div id="routerApp"><button class="homeLink"></button><button class="userLink" data-calc-id="5"></button><div class="content"></div></div>');
     const { view } = createRouterView(window.Ity);
     const btn = document.querySelector('.userLink') as HTMLElement;
-    btn.dispatchEvent(new window.Event('click'));
+    btn.dispatchEvent(new window.Event('click', { bubbles: true }));
     assert.strictEqual(view.model.get('page'), 'User 5');
     cleanup();
   });

--- a/test/view.test.ts
+++ b/test/view.test.ts
@@ -63,7 +63,7 @@ describe('View functionality', function () {
     const container = document.querySelector('.c');
     container.innerHTML = '<button class="btn"></button>';
     const btn = container.querySelector('button');
-    btn.dispatchEvent(new window.Event('click'));
+    btn.dispatchEvent(new window.Event('click', { bubbles: true }));
     assert(clicked);
     cleanup();
   });


### PR DESCRIPTION
## Summary
- update `setupDOM` to reuse Jest's jsdom instance instead of replacing globals
- ensure click events bubble in dynamic element tests

## Testing
- `npm test`