### PR TITLE
Move misc coverage tests into appropriate suites

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -28,9 +28,10 @@ const config: Config = {
   coverageDirectory: "coverage",
 
   // An array of regexp pattern strings used to skip coverage collection
-  // coveragePathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  coveragePathIgnorePatterns: [
+    "/node_modules/",
+    "build/test/helpers.js",
+  ],
 
   // Indicates which provider should be used to instrument code for coverage
   coverageProvider: "v8",

--- a/test/view.test.ts
+++ b/test/view.test.ts
@@ -91,6 +91,33 @@ describe('View functionality', function () {
     cleanup();
   });
 
+  it('off with no args clears all listeners', function () {
+    const cleanup = setupDOM('<!DOCTYPE html><div id="v"></div>');
+    const view = new window.Ity.View({ el: '#v' });
+    let called = false;
+    view.on('foo', () => called = true);
+    view.on('bar', () => called = true);
+    view.off();
+    view.trigger('foo');
+    view.trigger('bar');
+    assert.strictEqual(called, false);
+    cleanup();
+  });
+
+  it('_setElement throws on invalid selector', function () {
+    const cleanup = setupDOM('<!DOCTYPE html><div id="v"></div>');
+    const view = new window.Ity.View();
+    assert.throws(() => (view as any)._setElement(5 as any));
+    cleanup();
+  });
+
+  it('select throws when given invalid context', function () {
+    const cleanup = setupDOM('<!DOCTYPE html><div id="v"><span></span></div>');
+    const view = new window.Ity.View({ el: '#v' });
+    assert.throws(() => view.select('span', {} as any));
+    cleanup();
+  });
+
   it('delegates focus events using capture', function () {
     const cleanup = setupDOM('<!DOCTYPE html><div id="v"><input id="i"></div>');
     let focused = false;


### PR DESCRIPTION
## Summary
- ignore build/test/helpers.js during coverage so node_modules remains ignored
- add tests for collection `_ajax` error path and `find` returning undefined
- add model tests for removing events and `_ajax` error scenarios
- add view tests for clearing events, invalid element setup and invalid select context

## Testing
- `npm test`